### PR TITLE
Retrieve tokens from secrets management

### DIFF
--- a/modules/sdwheeler.GitTools/sdwheeler.GitTools.psm1
+++ b/modules/sdwheeler.GitTools/sdwheeler.GitTools.psm1
@@ -11,7 +11,7 @@ function GetIterationPaths {
     $baseurl = 'https://dev.azure.com/msft-skilling/content/powershell/_apis'
     $apiurl = 'work/teamsettings/iterations?api-version=7.0'
     $username = ' '
-    $password = ConvertTo-SecureString $env:CLDEVOPS_TOKEN -AsPlainText -Force
+    $password = Get-Secret -Name CLDEVOPS_TOKEN
     $cred = [PSCredential]::new($username, $password)
     $params = @{
             uri            = "$baseurl/$apiurl"
@@ -87,7 +87,7 @@ function Get-RepoData {
                 $apiurl = 'https://api.github.com/repos/' + $currentRepo.id
                 $hdr = @{
                     Accept        = 'application/vnd.github.json'
-                    Authorization = "token ${Env:\GITHUB_TOKEN}"
+                    Authorization = "token $(Get-Secret -Name GITHUB_TOKEN -AsPlainText)"
                 }
                 break
             }
@@ -492,7 +492,7 @@ function Get-RepoStatus {
     )
     $hdr = @{
         Accept        = 'application/vnd.github.VERSION.full+json'
-        Authorization = "token ${Env:\GITHUB_TOKEN}"
+        Authorization = "token $(Get-Secret -Name GITHUB_TOKEN -AsPlainText)"
     }
 
     $azlist = 'MicrosoftDocs/azure-docs-powershell', 'Azure/azure-docs-powershell-samples',
@@ -665,7 +665,7 @@ function Invoke-GitHubApi {
     }
     $hdr = @{
         Accept        = 'application/vnd.github.v3.raw+json'
-        Authorization = "token ${Env:\GITHUB_TOKEN}"
+        Authorization = "token $(Get-Secret -Name GITHUB_TOKEN -AsPlainText)"
     }
     $results = Invoke-RestMethod -Headers $hdr -Uri $uri -Method $method -FollowRelLink
     foreach ($page in $results) { $page }
@@ -713,7 +713,7 @@ function Import-GitHubLabels {
 
     $hdr = @{
         Accept        = 'application/vnd.github.v3+json'
-        Authorization = "token ${Env:\GITHUB_TOKEN}"
+        Authorization = "token $(Get-Secret -Name GITHUB_TOKEN -AsPlainText)"
     }
     $api = "https://api.github.com/repos/$RepoName/labels"
 
@@ -744,7 +744,7 @@ function Get-PrFiles {
     )
     $hdr = @{
         Accept        = 'application/vnd.github.VERSION.full+json'
-        Authorization = "token ${Env:\GITHUB_TOKEN}"
+        Authorization = "token $(Get-Secret -Name GITHUB_TOKEN -AsPlainText)"
     }
 
     $pr = Invoke-RestMethod "https://api.github.com/repos/$repo/pulls/$num" -Method GET -head $hdr -FollowRelLink
@@ -771,7 +771,7 @@ function Get-PrMerger {
 
     $hdr = @{
         Accept        = 'application/vnd.github.v3+json'
-        Authorization = "token ${Env:\GITHUB_TOKEN}"
+        Authorization = "token $(Get-Secret -Name GITHUB_TOKEN -AsPlainText)"
     }
     $query = "q=type:pr+is:merged+repo:$RepoName"
 
@@ -806,7 +806,7 @@ function Get-Issue {
 
     $hdr = @{
         Accept        = 'application/vnd.github.v3+json'
-        Authorization = "token ${Env:\GITHUB_TOKEN}"
+        Authorization = "token $(Get-Secret -Name GITHUB_TOKEN -AsPlainText)"
     }
     if ($null -ne $IssueUrl) {
         $RepoName = ($IssueUrl.Segments[1..2] -join '').trim('/')
@@ -840,7 +840,7 @@ function Get-IssueList {
     )
     $hdr = @{
         Accept        = 'application/vnd.github.v3.raw+json'
-        Authorization = "token ${Env:\GITHUB_TOKEN}"
+        Authorization = "token $(Get-Secret -Name GITHUB_TOKEN -AsPlainText)"
     }
     $apiurl = "https://api.github.com/repos/$RepoName/issues"
     $results = (Invoke-RestMethod $apiurl -Headers $hdr -FollowRelLink)
@@ -874,7 +874,7 @@ function New-PrFromBranch {
     $repo = (Show-RepoData)
     $hdr = @{
         Accept        = 'application/vnd.github.raw+json'
-        Authorization = "token ${Env:\GITHUB_TOKEN}"
+        Authorization = "token $(Get-Secret -Name GITHUB_TOKEN -AsPlainText)"
     }
     $apiurl = "https://api.github.com/repos/$($repo.id)/pulls"
 
@@ -960,7 +960,7 @@ function Get-DevOpsWorkItem {
     if (-not $Verbose) {$Verbose = $false}
 
     $username = ' '
-    $password = ConvertTo-SecureString $env:CLDEVOPS_TOKEN -AsPlainText -Force
+    $password = Get-Secret -Name CLDEVOPS_TOKEN
     $cred = [PSCredential]::new($username, $password)
 
     $vsuri = 'https://dev.azure.com'
@@ -1018,7 +1018,7 @@ function New-DevOpsWorkItem {
     if (-not $Verbose) {$Verbose = $false}
 
     $username = ' '
-    $password = ConvertTo-SecureString $env:CLDEVOPS_TOKEN -AsPlainText -Force
+    $password = Get-Secret -Name CLDEVOPS_TOKEN
     $cred = [PSCredential]::new($username, $password)
 
     $vsuri = 'https://dev.azure.com'
@@ -1161,7 +1161,7 @@ function Update-DevOpsWorkItem {
     if (-not $Verbose) {$Verbose = $false}
 
     $username = ' '
-    $password = ConvertTo-SecureString $env:CLDEVOPS_TOKEN -AsPlainText -Force
+    $password = Get-Secret -Name CLDEVOPS_TOKEN
     $cred = [PSCredential]::new($username, $password)
 
     $vsuri = 'https://dev.azure.com'
@@ -1462,7 +1462,7 @@ function New-MergeToLive {
     )
     $hdr = @{
         Accept        = 'application/vnd.github.v3+json'
-        Authorization = "token ${Env:\GITHUB_TOKEN}"
+        Authorization = "token $(Get-Secret -Name GITHUB_TOKEN -AsPlainText)"
     }
     $apiurl = "https://api.github.com/repos/$($repo.id)/pulls"
     $params = @{


### PR DESCRIPTION
Convert to retrieving tokens from secrets management instead of using environment variables. Create a vault unless you already have one and add the tokens to it before attempting to use the updated module.

```powershell
Install-Module -Name Microsoft.PowerShell.SecretManagement, Microsoft.PowerShell.SecretStore
Register-SecretVault -Name SecretStore -ModuleName Microsoft.PowerShell.SecretStore -DefaultVault
$GITHUB_TOKEN = Read-Host -Prompt 'Enter token' -AsSecureString
Set-Secret -Name GITHUB_TOKEN -SecureStringSecret $GITHUB_TOKEN
$CLDEVOPS_TOKEN = Read-Host -Prompt 'Enter token' -AsSecureString
Set-Secret -Name CLDEVOPS_TOKEN -SecureStringSecret $CLDEVOPS_TOKEN
```